### PR TITLE
Support summing over guider images.

### DIFF
--- a/py/ci_reduce/image.py
+++ b/py/ci_reduce/image.py
@@ -15,8 +15,13 @@ class CI_image:
     def __init__(self, image, header, cube_index=None):
         if cube_index is None:
             self.image = image.astype('float32')
+            self.nframe = 1
+        elif cube_index == -1:
+            self.image = np.mean(image.astype('float32'), axis=0)
+            self.nframe = image.shape[0]
         else:
             self.image = image[cube_index, :, :].astype('float32')
+            self.nframe = 1
 
         self.remove_overscan()
             
@@ -60,6 +65,7 @@ class CI_image:
 
         var_e_sq = (common.ci_camera_readnoise(ci_extname)**2 + \
                     self.image*(self.image >= 0)*gain)
+        var_e_sq /= self.nframe
 
         assert(np.sum(var_e_sq <= 0) == 0)
         self.var_e_sq = var_e_sq

--- a/py/ci_reduce/io.py
+++ b/py/ci_reduce/io.py
@@ -102,8 +102,9 @@ def load_exposure(fname, verbose=True, realtime=False, cube_index=None):
     
     try:
         imlist = [load_image_from_hdu(hdul[ind], verbose=verbose, cube_index=cube_index) for ind in w_im]
-    except:
+    except Exception as e:
         print('failed to load exposure at image list creation stage')
+        print(e)
         return None
 
     exp = CI_exposure(imlist, dummy_fz_header=dummy_fz_header)


### PR DESCRIPTION
Adds feature letting gfa_reduce to sum over guide cubes.

Slightly clumsy in that the filenames produced are gfa-EXPID--00001.fits, but not crazy.  I think I handled the variance right, but I'm not sure.