### PR TITLE
Updates for 26.3

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,11 +16,17 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-latest]
-                python-version: ['3.10']  #, '3.11'] There are still issues with Numpy <1.23 and 3.11.
-                numpy-version: ['<1.23']
-                astropy-version: ['<6.0', '<7.0']
-                desimeter-version: ['0.7.0']
+                include:
+                    - os: ubuntu-latest
+                      python-version: '3.13'
+                      numpy-version: '<2.4'
+                      astropy-version: '<8.0'
+                      desimeter-version: '0.9.0'
+                    - os: ubuntu-latest
+                      python-version: '3.10'
+                      numpy-version: '<1.23'
+                      astropy-version: '<6.1'
+                      desimeter-version: '0.7.0'
 
         steps:
             - name: Checkout code
@@ -49,7 +55,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: ['3.10']
                 numpy-version: ['<1.23']
-                astropy-version: ['<6.0']
+                astropy-version: ['<6.1']
                 desimeter-version: ['0.7.0']
 
         steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip setuptools wheel
+                python -m pip install --upgrade pip setuptools\<80 wheel
                 python -m pip install --upgrade "numpy${{ matrix.numpy-version }}"
                 python -m pip install --upgrade "astropy${{ matrix.astropy-version }}"
                 python -m pip install desiutil
@@ -67,7 +67,7 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip setuptools wheel
+                python -m pip install --upgrade pip setuptools\<80 wheel
                 python -m pip install --upgrade "numpy${{ matrix.numpy-version }}"
                 python -m pip install --upgrade "astropy${{ matrix.astropy-version }}"
                 python -m pip install desiutil

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9', '3.10']  #, '3.11'] There are still issues with Numpy <1.23 and 3.11.
+                python-version: ['3.10']  #, '3.11'] There are still issues with Numpy <1.23 and 3.11.
                 numpy-version: ['<1.23']
                 astropy-version: ['<6.0', '<7.0']
                 desimeter-version: ['0.7.0']

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,24 +21,21 @@ jobs:
                 numpy-version: ['<1.23']
                 astropy-version: ['<6.0', '<7.0']
                 desimeter-version: ['0.7.0']
-                desiutil-version: ['3.4.2']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
-              with:
-                fetch-depth: 0
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v6
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install "git+https://github.com/desihub/desiutil.git@${{ matrix.desiutil-version }}#egg=desiutil"
-                python -m pip install "git+https://github.com/desihub/desimeter.git@${{ matrix.desimeter-version }}#egg=desimeter"
                 python -m pip install --upgrade "numpy${{ matrix.numpy-version }}"
                 python -m pip install --upgrade "astropy${{ matrix.astropy-version }}"
+                python -m pip install desiutil
+                python -m pip install "git+https://github.com/desihub/desimeter.git@${{ matrix.desimeter-version }}#egg=desimeter"
                 python -m pip install --editable .[test]
             - name: Run the test
               run: pytest
@@ -54,24 +51,21 @@ jobs:
                 numpy-version: ['<1.23']
                 astropy-version: ['<6.0']
                 desimeter-version: ['0.7.0']
-                desiutil-version: ['3.4.2']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
-              with:
-                fetch-depth: 0
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v6
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install "git+https://github.com/desihub/desiutil.git@${{ matrix.desiutil-version }}#egg=desiutil"
-                python -m pip install "git+https://github.com/desihub/desimeter.git@${{ matrix.desimeter-version }}#egg=desimeter"
                 python -m pip install --upgrade "numpy${{ matrix.numpy-version }}"
                 python -m pip install --upgrade "astropy${{ matrix.astropy-version }}"
+                python -m pip install desiutil
+                python -m pip install "git+https://github.com/desihub/desimeter.git@${{ matrix.desimeter-version }}#egg=desimeter"
                 python -m pip install --editable .[coverage]
             - name: Run the test with coverage
               run: pytest --cov
@@ -92,11 +86,9 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
-              with:
-                fetch-depth: 0
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v6
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
@@ -112,21 +104,18 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: ['3.10']
-                desiutil-version: ['3.4.2']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install "git+https://github.com/desihub/desiutil.git@${{ matrix.desiutil-version }}#egg=desiutil"
+                python -m pip install desiutil
             - name: Generate api.rst
               run: |
                 desi_api_file --api ./api.rst gfa_reduce
@@ -145,11 +134,9 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
-              with:
-                fetch-depth: 0
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v6
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies

--- a/py/gfa_reduce/analysis/phot.py
+++ b/py/gfa_reduce/analysis/phot.py
@@ -14,11 +14,14 @@ from scipy import ndimage
 import numpy as np
 from scipy.ndimage.measurements import label, find_objects
 from astropy.table import Table
-#from photutils.centroids.core import fit_2dgaussian
 from gfa_reduce.analysis.gaussian import fit_2dgaussian
 from astropy.stats import sigma_clipped_stats
-from photutils import aperture_photometry
-from photutils import CircularAperture, CircularAnnulus, EllipticalAperture
+try:
+    # photutils >= 2.0
+    from photutils.aperture import aperture_photometry, CircularAperture, CircularAnnulus, EllipticalAperture
+except ImportError:
+    # photutils < 2.0
+    from photutils import aperture_photometry, CircularAperture, CircularAnnulus, EllipticalAperture
 import gfa_reduce.common as common
 import gfa_reduce.analysis.djs_maskinterp as djs_maskinterp
 from gfa_reduce.analysis.djs_photcen import _loop_djs_photcen

--- a/py/gfa_reduce/analysis/segment.py
+++ b/py/gfa_reduce/analysis/segment.py
@@ -6,17 +6,36 @@ gfa_reduce.analysis.segment
 
 Segment a 2D numpy array.
 """
+import numpy as np
 import gfa_reduce.common as common
 import gfa_reduce.analysis.util as util
-from photutils import detect_threshold
 from astropy.convolution import Gaussian2DKernel
-import numpy as np
 from astropy.stats import gaussian_fwhm_to_sigma
-from photutils import detect_sources
+try:
+    # photutils >= 2.0
+    from photutils.detection import detect_threshold, detect_sources
+except ImportError:
+    # photutils < 2.0
+    from photutils import detect_threshold, detect_sources
+
 
 def segmentation_map(image, extname, get_kernel=False):
-    # in this context image means a 2D numpy array rather than a GFA_image
-    # object
+    """Perform segmentation on `image`.
+
+    Parameters
+    ----------
+    image : :class:`numpy.ndarray`
+        A 2D NumPy array rather than a GFA_image object.
+    extname : :class:`str`
+        This parameter does not appear to be used.
+    get_kernel : :class:`bool`, optional
+        If ``True``, return the kernel used in segmentation.
+
+    Returns
+    -------
+    :class:`~photutils.segmentation.SegmentationImage`
+        A segmentation image.
+    """
 
     par = common.gfa_misc_params()
 

--- a/py/gfa_reduce/analysis/segment.py
+++ b/py/gfa_reduce/analysis/segment.py
@@ -13,7 +13,7 @@ from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
 try:
     # photutils >= 2.0
-    from photutils.detection import detect_threshold, detect_sources
+    from photutils.segmentation import detect_threshold, detect_sources
 except ImportError:
     # photutils < 2.0
     from photutils import detect_threshold, detect_sources

--- a/py/gfa_reduce/analysis/util.py
+++ b/py/gfa_reduce/analysis/util.py
@@ -10,7 +10,15 @@ import gfa_reduce.common as common
 import numpy as np
 import os
 from astropy.table import Table
-from astropy.coordinates import SkyCoord, AltAz, get_sun, get_moon
+from astropy.coordinates import SkyCoord, AltAz, get_sun
+_has_get_moon = False
+try:
+    # astropy >= 7
+    from astropy.coordinates import get_body
+except ImportError:
+    # astropy < 7
+    from astropy.coordinates import get_moon
+    _has_get_moon = True
 from astropy.io import fits
 from astropy.time import Time
 from astropy.stats import sigma_clipped_stats
@@ -806,7 +814,10 @@ def coadd_cube_index_range(bintable, cube_index, mjdrange):
 # from John Moustakas notebook
 def moon_phase_angle(time, location):
     sun = get_sun(time).transform_to(AltAz(location=location, obstime=time))
-    moon = get_moon(time, location)
+    if _has_get_moon:
+        moon = get_moon(time, location)
+    else:
+        moon = get_body('moon', time, location=location)
     elongation = sun.separation(moon)
     return np.arctan2(sun.distance*np.sin(elongation),
                       moon.distance - sun.distance*np.cos(elongation))

--- a/py/gfa_reduce/analysis/util.py
+++ b/py/gfa_reduce/analysis/util.py
@@ -10,25 +10,24 @@ import gfa_reduce.common as common
 import numpy as np
 import os
 from astropy.table import Table
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, AltAz, get_sun, get_moon
+from astropy.io import fits
+from astropy.time import Time
+from astropy.stats import sigma_clipped_stats
 from astropy import units as u
 from scipy.ndimage.interpolation import shift
-import astropy.io.fits as fits
 from scipy.optimize import minimize
 import gfa_reduce.xmatch.gaia as gaia
-from astropy.time import Time
-import astropy
 from datetime import datetime
 try:
-    # photutils >= 2.0
-    from photutils.aperture import aperture_photometry
+    # photutils >= 2.0; EllipticalAperture does not appear to be used.
+    from photutils.aperture import aperture_photometry, CircularAperture, CircularAnnulus  # , EllipticalAperture
 except ImportError:
     # photutils < 2.0
-    from photutils import aperture_photometry
-from photutils import CircularAperture, CircularAnnulus, EllipticalAperture
-import photutils
-from astropy.stats import sigma_clipped_stats
+    from photutils import aperture_photometry, CircularAperture, CircularAnnulus  # , EllipticalAperture
+from photutils import __version__ as photutils_version
 from desiutil.log import get_logger
+
 
 def use_for_fwhm_meas(tab, bad_amps=None, snr_thresh=20,
                       no_sig_major_cut=False):
@@ -423,7 +422,6 @@ def _stamp_radius_mask(sidelen, return_radius=False,
         return mask, dist.reshape(sidelen, sidelen)
 
 def _test_shift():
-    import astropy.io.fits as fits
     im = fits.getdata('gaussian.fits')
 
     result = _shift_stamp(im, 0.5, 0.0)
@@ -807,9 +805,8 @@ def coadd_cube_index_range(bintable, cube_index, mjdrange):
 
 # from John Moustakas notebook
 def moon_phase_angle(time, location):
-    sun = astropy.coordinates.get_sun(time).transform_to(astropy.coordinates.AltAz(
-        location=location, obstime=time))
-    moon = astropy.coordinates.get_moon(time, location)
+    sun = get_sun(time).transform_to(AltAz(location=location, obstime=time))
+    moon = get_moon(time, location)
     elongation = sun.separation(moon)
     return np.arctan2(sun.distance*np.sin(elongation),
                       moon.distance - sun.distance*np.cos(elongation))
@@ -948,7 +945,7 @@ def get_obs_night_now(verbose=False):
 def _get_area_from_ap(ap):
     # this is to try and work around the photutils API change
     # between versions 0.6 and 0.7+
-    if photutils.__version__.find('0.6') != -1:
+    if photutils_version.find('0.6') != -1:
         area = ap.area() # 0.6
     else:
         area = ap.area # 0.7 or above

--- a/py/gfa_reduce/analysis/util.py
+++ b/py/gfa_reduce/analysis/util.py
@@ -19,7 +19,12 @@ import gfa_reduce.xmatch.gaia as gaia
 from astropy.time import Time
 import astropy
 from datetime import datetime
-from photutils import aperture_photometry
+try:
+    # photutils >= 2.0
+    from photutils.aperture import aperture_photometry
+except ImportError:
+    # photutils < 2.0
+    from photutils import aperture_photometry
 from photutils import CircularAperture, CircularAnnulus, EllipticalAperture
 import photutils
 from astropy.stats import sigma_clipped_stats

--- a/py/gfa_reduce/test/test_analysis.py
+++ b/py/gfa_reduce/test/test_analysis.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.analysis.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from ..analysis import (amm_2dhist, asterisms, basic_catalog_stats,
+                        basic_image_stats, center_contrast, djs_maskinterp,
+                        djs_photcen, dm, gaussian, phot, radprof,
+                        recalib_astrom, segment, sky, splinefwhm, util)
+
+
+class TestAnalysis(unittest.TestCase):
+    """Test gfa_reduce.analysis.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_common.py
+++ b/py/gfa_reduce/test/test_common.py
@@ -6,7 +6,7 @@ import unittest
 import os
 import tempfile
 from shutil import rmtree
-from ..common import retrieve_git_rev
+from .. import common
 
 
 class TestCommon(unittest.TestCase):
@@ -30,7 +30,7 @@ class TestCommon(unittest.TestCase):
     def test_retrieve_git_rev(self):
         """Test git revision in a git checkout.
         """
-        foo = retrieve_git_rev()
+        foo = common.retrieve_git_rev()
         self.assertRegex(foo, '[0-9a-f]+')
 
     def test_retrieve_git_rev_no_checkout(self):
@@ -40,5 +40,5 @@ class TestCommon(unittest.TestCase):
         with open(test_file, 'w') as f:
             f.write('This is a test.')
         with self.assertRaises(RuntimeError) as e:
-            foo = retrieve_git_rev(test_file)
+            foo = common.retrieve_git_rev(test_file)
         os.remove(test_file)

--- a/py/gfa_reduce/test/test_cube_proc.py
+++ b/py/gfa_reduce/test/test_cube_proc.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.cube_proc.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from .. import cube_proc
+
+
+class TestCubeProc(unittest.TestCase):
+    """Test gfa_reduce.cube_proc.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_dark_current.py
+++ b/py/gfa_reduce/test/test_dark_current.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.dark_current.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from .. import dark_current
+
+
+class TestDarkCurrent(unittest.TestCase):
+    """Test gfa_reduce.dark_current.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_exposure.py
+++ b/py/gfa_reduce/test/test_exposure.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.exposure.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from .. import exposure
+
+
+class TestExposure(unittest.TestCase):
+    """Test gfa_reduce.exposure.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_gfa_red.py
+++ b/py/gfa_reduce/test/test_gfa_red.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.gfa_red.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from .. import gfa_red
+
+
+class TestGFARed(unittest.TestCase):
+    """Test gfa_reduce.gfa_red.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_gfa_wcs.py
+++ b/py/gfa_reduce/test/test_gfa_wcs.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.gfa_wcs.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from .. import gfa_wcs
+
+
+class TestGFAWCS(unittest.TestCase):
+    """Test gfa_reduce.gfa_wcs.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_image.py
+++ b/py/gfa_reduce/test/test_image.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.image.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from .. import image
+
+
+class TestImage(unittest.TestCase):
+    """Test gfa_reduce.image.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_imred_dq_mask.py
+++ b/py/gfa_reduce/test/test_imred_dq_mask.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.imred.dq_mask.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from ..imred import dq_mask
+
+
+class TestImredDQMask(unittest.TestCase):
+    """Test gfa_reduce.imred.dq_mask.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_imred_load_calibs.py
+++ b/py/gfa_reduce/test/test_imred_load_calibs.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.imred.load_calibs.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from ..imred import load_calibs
+
+
+class TestImredLoadCalibs(unittest.TestCase):
+    """Test gfa_reduce.imred.load_calibs.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_io.py
+++ b/py/gfa_reduce/test/test_io.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.io.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from .. import io
+
+
+class TestIO(unittest.TestCase):
+    """Test gfa_reduce.io.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_scripts_concat_ccds.py
+++ b/py/gfa_reduce/test/test_scripts_concat_ccds.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.scripts.concat_ccds.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from ..scripts import concat_ccds
+
+
+class TestScriptsConcatCCDs(unittest.TestCase):
+    """Test gfa_reduce.scripts.concat_ccds.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_scripts_daily_summary.py
+++ b/py/gfa_reduce/test/test_scripts_daily_summary.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.scripts.daily_summary.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from ..scripts import daily_summary
+
+
+class TestScriptsDailySummary(unittest.TestCase):
+    """Test gfa_reduce.scripts.daily_summary.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_scripts_gfa_single_night.py
+++ b/py/gfa_reduce/test/test_scripts_gfa_single_night.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.scripts.gfa_single_night.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from ..scripts import gfa_single_night
+
+
+class TestScriptsGFASingleNight(unittest.TestCase):
+    """Test gfa_reduce.scripts.gfa_single_night.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/py/gfa_reduce/test/test_xmatch_gaia.py
+++ b/py/gfa_reduce/test/test_xmatch_gaia.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test gfa_reduce.xmatch.gaia.
+"""
+import unittest
+import os
+import tempfile
+from shutil import rmtree
+from ..xmatch import gaia
+
+
+class TestXmatchGaia(unittest.TestCase):
+    """Test gfa_reduce.xmatch.gaia.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmp)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_something(self):
+        pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,12 +3,12 @@ name = gfa_reduce
 version = attr: gfa_reduce.__version__
 author = DESI Collaboration
 author_email = desi-data@desi.lbl.gov
-license = BSD 3-Clause License
-license_files = LICENSE.rst
+license = BSD-3-Clause
+license_files = LICENSE
 url = https://github.com/desihub/gfa_reduce
-description = DESI utilities package
-long_description = file: README.rst
-long_description_content_type = text/x-rst
+description = DESI GFA off-line reduction/analysis pipeline
+long_description = file: README.md
+long_description_content_type = text/markdown
 edit_on_github = True
 github_project = desihub/gfa_reduce
 classifiers =
@@ -26,10 +26,10 @@ package_dir =
     =py
 packages = find:
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.10
 # setup_requires = setuptools_scm
 install_requires =
-    numpy<1.23
+    numpy
     astropy>=5.2
     healpy>=1.16.1
     photutils>=1.6.0


### PR DESCRIPTION
This PR allows the nightly GFA summary script to run on `desimodules/26.3`. It currently runs on `desimodules/main`, but that will eventually be supplanted.

The biggest non-cosmetic code changes are due to API changes in astropy and photutils.

I ran a comparison test as follows:

1. I copied `${DESI_ROOT}/survey/GFA/offline_matched_coadd_ccds_main-thru_20260505.fits` to `${DESI_ROOT}/survey/GFA.test.26.3`.
2. I created a separate intermediate reduction directory, `${DESI_ROOT}/users/desi/GFA/reduced/realtime_matched.test.26.3`. 
3. With `desimodules/26.3` and this branch, I ran the script `desi_gfa_reduce_daily_summary` on nights 20260506, 20260507, 20260508, 20260509, 20260510, 20260511.
4. I compared the resulting file `${DESI_ROOT}/survey/GFA.test.26.3/offline_matched_coadd_ccds_main-thru_20260511.fits` to `${DESI_ROOT}/survey/GFA/offline_matched_coadd_ccds_main-thru_20260511.fits`. I could not find any numerical differences.
5. I would encourage you to do the comparison yourself. A helper notebook can be found in `${DESI_ROOT}/users/bweaver/JupyterNotebooks/test_gfa_reduce_26.3.ipynb`.

I'm still working on some test failures.